### PR TITLE
Don't listen for SIGPIPE

### DIFF
--- a/signals.js
+++ b/signals.js
@@ -23,7 +23,6 @@ module.exports = [
   'SIGILL',
   'SIGINT',
   'SIGIOT',
-  'SIGPIPE',
   'SIGPROF',
   'SIGQUIT',
   'SIGSEGV',

--- a/test/signal-exit-test.js
+++ b/test/signal-exit-test.js
@@ -102,4 +102,13 @@ describe('signal-exit', function () {
       done()
     })
   })
+
+  it('does not exit on sigpipe', function (done) {
+    exec(process.execPath + ' ./test/fixtures/sigpipe.js', shell, function (err, stdout, stderr) {
+      assert.ifError(err)
+      stdout.should.match(/hello/)
+      stderr.should.match(/onSignalExit\(0,null\)/)
+      done()
+    })
+  })
 })


### PR DESCRIPTION
See #19 for detailed background, but in short:

`SIGPIPE` normally doesn't cause node to exit. However, by registering and unregistering a `process` `"SIGPIPE"` event handler, the behavior changes and node starts exiting when receiving `SIGPIPE` signals.

Because *signal-exit* listens for `SIGPIPE`, it causes programs to exit when receiving `SIGPIPE`, whereas normally node programs not using *signal-exit* should not exit when receiving `SIGPIPE`.

This changes *signal-exit* to not listen for `SIGPIPE` and tests that a program using *signal-exit* will not exit due to `SIGPIPE` signals. The test uses an existing test fixture (test/fixtures/sigpipe.js) that was not previously being used.

I've been using this change in production for a few weeks now without issue.