### PR TITLE
fix: hooking SIGPROF was interfering with profilers see #21

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Build Status](https://travis-ci.org/tapjs/signal-exit.png)](https://travis-ci.org/tapjs/signal-exit)
 [![Coverage](https://coveralls.io/repos/tapjs/signal-exit/badge.svg?branch=master)](https://coveralls.io/r/tapjs/signal-exit?branch=master)
 [![NPM version](https://img.shields.io/npm/v/signal-exit.svg)](https://www.npmjs.com/package/signal-exit)
-[![Windows Tests](https://img.shields.io/appveyor/ci/tapjs/signal-exit/master.svg?label=Windows%20Tests)](https://ci.appveyor.com/project/tapjs/signal-exit)
+[![Windows Tests](https://img.shields.io/appveyor/ci/bcoe/signal-exit/master.svg?label=Windows%20Tests)](https://ci.appveyor.com/project/bcoe/signal-exit)
 
 When you want to fire an event no matter how a process exits:
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![Coverage](https://coveralls.io/repos/tapjs/signal-exit/badge.svg?branch=master)](https://coveralls.io/r/tapjs/signal-exit?branch=master)
 [![NPM version](https://img.shields.io/npm/v/signal-exit.svg)](https://www.npmjs.com/package/signal-exit)
 [![Windows Tests](https://img.shields.io/appveyor/ci/bcoe/signal-exit/master.svg?label=Windows%20Tests)](https://ci.appveyor.com/project/bcoe/signal-exit)
+[![Standard Version](https://img.shields.io/badge/release-standard%20version-brightgreen.svg)](https://github.com/conventional-changelog/standard-version)
 
 When you want to fire an event no matter how a process exits:
 

--- a/package.json
+++ b/package.json
@@ -4,9 +4,10 @@
   "description": "when you want to fire an event no matter how a process exits.",
   "main": "index.js",
   "scripts": {
-    "posttest": "standard",
+    "pretest": "standard",
     "test": "tap --timeout=240 ./test/*.js --cov",
-    "coverage": "nyc report --reporter=text-lcov | coveralls"
+    "coverage": "nyc report --reporter=text-lcov | coveralls",
+    "release": "standard-version"
   },
   "files": [
     "index.js",
@@ -27,10 +28,11 @@
   },
   "homepage": "https://github.com/tapjs/signal-exit",
   "devDependencies": {
-    "chai": "^2.3.0",
+    "chai": "^3.5.0",
     "coveralls": "^2.11.2",
-    "nyc": "^5.1.0",
-    "standard": "^3.9.0",
-    "tap": "^4.0.0"
+    "nyc": "^6.4.4",
+    "standard": "^7.1.2",
+    "standard-version": "^2.3.0",
+    "tap": "^5.7.2"
   }
 }

--- a/signals.js
+++ b/signals.js
@@ -34,8 +34,10 @@ if (process.platform !== 'win32') {
     'SIGTRAP',
     'SIGSYS',
     'SIGQUIT',
-    'SIGIOT',
-    'SIGPROF'
+    'SIGIOT'
+    // should detect profiler and enable/disable accordingly.
+    // see #21
+    // 'SIGPROF'
   )
 }
 

--- a/test/all-integration-test.js
+++ b/test/all-integration-test.js
@@ -12,7 +12,6 @@ require('tap').mochaGlobals()
 var onSignalExit = require('../')
 
 describe('all-signals-integration-test', function () {
-
   // These are signals that are aliases for other signals, so
   // the result will sometimes be one of the others.  For these,
   // we just verify that we GOT a signal, not what it is.

--- a/test/fixtures/change-code.js
+++ b/test/fixtures/change-code.js
@@ -1,7 +1,9 @@
+var join = require('path').join
+
 if (process.argv.length === 2) {
   var types = [ 'explicit', 'code', 'normal' ]
   var codes = [ 0, 2, 'null' ]
-  var changes = [ 'nochange', 'change', 'code', 'twice', 'twicecode']
+  var changes = [ 'nochange', 'change', 'code', 'twice', 'twicecode' ]
   var handlers = [ 'sigexit', 'nosigexit' ]
   var opts = []
   types.forEach(function (type) {
@@ -77,7 +79,7 @@ function listener (code, signal) {
 function run (opt) {
   console.error(opt)
   var shell = process.platform === 'win32' ? null : { shell: '/bin/bash' }
-  exec(process.execPath + ' ' + __filename + ' ' + opt, shell, function (err, stdout, stderr) {
+  exec(join(process.execPath, ' ', __filename, ' ' + opt), shell, function (err, stdout, stderr) {
     var res = JSON.parse(stdout)
     if (err) {
       res.actualCode = err.code

--- a/test/fixtures/exiter.js
+++ b/test/fixtures/exiter.js
@@ -33,7 +33,6 @@ if (isNaN(exit)) {
   } catch (er) {
     wanted = [ 0, null ]
   }
-
 } else {
   exit = +exit
   wanted = [ exit, null ]

--- a/test/fixtures/multiple-load.js
+++ b/test/fixtures/multiple-load.js
@@ -15,7 +15,7 @@ onSignalExit(function (code, signal) {
 })
 
 delete require('module')._cache[require.resolve('../../')]
-var onSignalExit = require('../../')
+onSignalExit = require('../../')
 
 onSignalExit(function (code, signal) {
   counter++
@@ -31,7 +31,7 @@ onSignalExit(function (code, signal) {
 
 // Lastly, some that should NOT be shown
 delete require('module')._cache[require.resolve('../../')]
-var onSignalExit = require('../../')
+onSignalExit = require('../../')
 
 var unwrap = onSignalExit(function (code, signal) {
   counter++

--- a/test/fixtures/signal-default.js
+++ b/test/fixtures/signal-default.js
@@ -25,7 +25,7 @@ if (process.argv[2]) {
     'SIGLOST',
     'SIGPIPE',
     'SIGPOLL',
-    'SIGPROF',
+    // 'SIGPROF', see #21
     'SIGPWR',
     'SIGQUIT',
     'SIGSEGV',

--- a/test/multi-exit.js
+++ b/test/multi-exit.js
@@ -23,7 +23,7 @@ var codes = [ 0, 2, 'null' ]
 
 // do not change, change to 5 with exit(), change to 5 with exitCode,
 // change to 5 and then to 2 with exit(), change twice with exitcode
-var changes = [ 'nochange', 'change', 'twice']
+var changes = [ 'nochange', 'change', 'twice' ]
 if (!isZero10()) changes.push('code', 'twicecode')
 
 // use signal-exit, use process.on('exit')

--- a/test/signal-exit-test.js
+++ b/test/signal-exit-test.js
@@ -11,7 +11,6 @@ require('chai').should()
 require('tap').mochaGlobals()
 
 describe('signal-exit', function () {
-
   it('receives an exit event when a process exits normally', function (done) {
     exec(node + ' ./test/fixtures/end-of-execution.js', shell, function (err, stdout, stderr) {
       expect(err).to.equal(null)


### PR DESCRIPTION
BREAKING CHANGE: signal-exit no longer wires into SIGPROF

Stop wiring into SIGPROF, this was causing issues discussed in #21 and https://github.com/npm/npmlog/issues/40