### PR TITLE
Do not listen on SIGBUS, SIGFPE, SIGSEGV and SIGILL

### DIFF
--- a/signals.js
+++ b/signals.js
@@ -13,15 +13,16 @@
 // fatal signal like SIGWINCH or something, and then
 // exit, it'll end up firing `process.emit('exit')`, so
 // the handler will be fired anyway.
+//
+// SIGBUS, SIGFPE, SIGSEGV and SIGILL, when not raised
+// artificially, inherently leave the process in a
+// state from which it is not safe to try and enter JS
+// listeners.
 module.exports = [
   'SIGABRT',
   'SIGALRM',
-  'SIGBUS',
-  'SIGFPE',
   'SIGHUP',
-  'SIGILL',
   'SIGINT',
-  'SIGSEGV',
   'SIGTERM'
 ]
 


### PR DESCRIPTION
Listening for one of these signals from JS will make the process enter an infinite loop when encountering them naturally because the underlying problem is not resolved while the signal handler is being scheduled.

Ref: https://github.com/npm/npm/issues/13782 (real problem caused by this :/)
Ref: https://github.com/nodejs/node/pull/8410 (me wanting to warn about this in the Node.js docs)