### PR TITLE
feature(types): add type definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,52 @@
+declare namespace signalExit {
+  export interface SignalExitOptions {
+    /**
+     * Run this handler after any other signal or exit handlers.
+     * This causes `process.emit` to be monkeypatched.
+     *
+     * Default: `false`
+     */
+    alwaysLast?: boolean;
+  }
+
+  /**
+   * Removes the corresponding listener.
+   */
+  export type RemoveListener = () => void;
+
+  /**
+   * The exit listener is passed two arguments.
+   *
+   * It is guaranteed that exactly one of them is `null` and the other not.
+   *
+   * - `code`: Exit code of the process. Present for example when Node exits
+   *   normally (end of program) or after `process.exit(code)`.
+   * - `signal`: Signal causing the process to exit. Present for example
+   *   when using `process.kill(process.pid, signal)`.
+   */
+  export type SignalExitListener = (code: number | null, signal: NodeJS.Signals | null) => any;
+
+  export interface SignalExit {
+    /**
+     * Adds a listener fired when the current process exits, no matter how.
+     *
+     * Note that the function *only* fires for signals if the signal would
+     * cause the proces to exit. That is, there are no other listeners, and
+     * it is a fatal signal.
+     *
+     * @param listener See [[SignalExitListener]].
+     * @param options See [[SignalExitOptions]].
+     * @return Function to remove the listener.
+     */
+    (listener: SignalExitListener, options?: Readonly<SignalExitOptions>): RemoveListener;
+
+    /**
+     * Returns the platform-dependent list of exit signals.
+     */
+    signals(): NodeJS.Signals[];
+  }
+}
+
+declare const signalExit: signalExit.SignalExit;
+
+export = signalExit;

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "3.0.2",
   "description": "when you want to fire an event no matter how a process exits.",
   "main": "index.js",
+  "types": "index.d.ts",
   "scripts": {
     "pretest": "standard",
     "test": "tap --timeout=240 ./test/*.js --cov",
@@ -11,6 +12,7 @@
   },
   "files": [
     "index.js",
+    "index.d.ts",
     "signals.js"
   ],
   "repository": {


### PR DESCRIPTION
# Why

See [my blog post on the benefits of type definitions](https://demurgos.net/blog/2018/09/19/why-type-definitions/).
`signal-exit` is extremely popular since it's used as a dependency of most code coverage tools. Writing down the public API in a strict format is a good way to specify the contracts of the API.

This PR is part of the effort to improve code coverage tools for Node as part of node-tooling group. I am going over the dependencies and checking them.

# What

Add type definitions for `signal-exit` and link them in `package.json`. From a semver point of view this is a feature. Even if it's mostly there for documentation purposes, it enables TS consumers to types for this lib.