### PR TITLE
gracefully no-op unwrap function

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,7 +19,9 @@ const processOk = function (process) {
 // some kind of non-node environment, just no-op
 /* istanbul ignore if */
 if (!processOk(process)) {
-  module.exports = function () {}
+  module.exports = function () {
+    return function () {}
+  }
 } else {
   var assert = require('assert')
   var signals = require('./signals.js')
@@ -52,7 +54,7 @@ if (!processOk(process)) {
   module.exports = function (cb, opts) {
     /* istanbul ignore if */
     if (!processOk(global.process)) {
-      return
+      return function () {}
     }
     assert.equal(typeof cb, 'function', 'a callback must be provided for exit handler')
 

--- a/test/fixtures/process-deleted.js
+++ b/test/fixtures/process-deleted.js
@@ -1,6 +1,10 @@
 var onSignalExit = require('../../')
 global.process = null
 
-onSignalExit(function (code, signal) {
+var unwrap = onSignalExit(function (code, signal) {
   throw new Error('this should not ever be called')
 })
+
+if (typeof unwrap !== 'function') {
+  throw new Error('missing unwrap function')
+}

--- a/test/fixtures/process-gone.js
+++ b/test/fixtures/process-gone.js
@@ -5,6 +5,10 @@ global.process = null
 delete require.cache[require.resolve('../../')]
 onSignalExit = require('../../')
 
-onSignalExit(function (code, signal) {
+var unwrap = onSignalExit(function (code, signal) {
   throw new Error('this should not ever be called')
 })
+
+if (typeof unwrap !== 'function') {
+  throw new Error('missing unwrap function')
+}


### PR DESCRIPTION
Return a no-op unwrap function to maintain implicitly expected behavior of `v3`

Fixes #68