### PR TITLE
Add `./package.json` to export map

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "browser": "./dist/mjs/browser.js",
   "types": "./dist/mjs/index.d.ts",
   "exports": {
+    "./package.json": "./package.json",
     ".": {
       "import": {
         "types": "./dist/mjs/index.d.ts",


### PR DESCRIPTION
When statically analyzing dependencies, I've found it pretty convenient to be able to access a dependency `./package.json` file directly.