### PR TITLE
fix: do not install SIGTRAP in electron

### DIFF
--- a/src/signals.ts
+++ b/src/signals.ts
@@ -35,7 +35,7 @@ if (process.platform !== 'win32') {
     'SIGXCPU',
     'SIGXFSZ',
     'SIGUSR2',
-    'SIGTRAP',
+  //'SIGTRAP',
     'SIGSYS',
     'SIGQUIT',
     'SIGIOT'
@@ -43,6 +43,9 @@ if (process.platform !== 'win32') {
     // see #21
     // 'SIGPROF'
   )
+  if (!process.versions.electron) {
+    signals.push('SIGTRAP');
+  }
 }
 
 if (process.platform === 'linux') {


### PR DESCRIPTION
electron/chromium will emit `SIGTRAP` when oom then make the process exit after collecting mindump.
The `SIGTRAP` handler we install can not be called when oom, which make app fall into an infinite loop, because chromium will emit `SIGTRAP` continually(such as by `brk` Instruction).

fixed: https://github.com/electron/electron/issues/50507

